### PR TITLE
조회수 증가 기능 리팩토링

### DIFF
--- a/src/main/java/com/shboard/shboard/board/application/BoardService.java
+++ b/src/main/java/com/shboard/shboard/board/application/BoardService.java
@@ -10,6 +10,7 @@ import com.shboard.shboard.board.exception.BoardException;
 import com.shboard.shboard.member.domain.Member;
 import com.shboard.shboard.member.domain.MemberRepository;
 import com.shboard.shboard.member.exception.MemberException;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +32,6 @@ public class BoardService {
         return BoardsResponse.of(boardPage, pageable);
     }
 
-    @Transactional(readOnly = true)
     public BoardDetailResponse readDetail(final Long boardId) {
         final Board findBoard = boardRepository.findById(boardId)
                 .orElseThrow(BoardException.NotFoundBoardException::new);

--- a/src/test/java/com/shboard/shboard/board/domain/CustomBoardRepositoryImplTest.java
+++ b/src/test/java/com/shboard/shboard/board/domain/CustomBoardRepositoryImplTest.java
@@ -36,7 +36,7 @@ class CustomBoardRepositoryImplTest extends RepositoryTest {
     class SearchByCondition {
 
         private int memberCount = 3;
-        private int totalPostCount = 10;
+        private int totalPostCount = 10 * defaultPageSize;
 
         @BeforeEach
         void setUp() {
@@ -115,8 +115,8 @@ class CustomBoardRepositoryImplTest extends RepositoryTest {
             // then
             assertSoftly(softly -> {
                 softly.assertThat(boards.getNumber()).isEqualTo(0);
-                softly.assertThat(boards.getTotalElements()).isEqualTo(2);
-                softly.assertThat(contents.size()).isEqualTo(2);
+                softly.assertThat(boards.getTotalElements()).isEqualTo(12);
+                softly.assertThat(contents.size()).isEqualTo(defaultPageSize);
                 softly.assertThat(contents)
                         .extracting(Board::getTitle)
                         .allMatch(title -> title.toUpperCase().contains(variousCaseSearchTitle.toUpperCase()));
@@ -138,8 +138,8 @@ class CustomBoardRepositoryImplTest extends RepositoryTest {
             // then
             assertSoftly(softly -> {
                 softly.assertThat(boards.getNumber()).isEqualTo(0);
-                softly.assertThat(boards.getTotalElements()).isEqualTo(3);
-                softly.assertThat(contents.size()).isEqualTo(3);
+                softly.assertThat(boards.getTotalElements()).isEqualTo(totalPostCount / memberCount);
+                softly.assertThat(contents.size()).isEqualTo(defaultPageSize);
                 softly.assertThat(contents)
                         .extracting(Board::getWriterNickname)
                         .allMatch(writerNickname -> writerNickname.equals(searchWriterNickname));
@@ -162,8 +162,8 @@ class CustomBoardRepositoryImplTest extends RepositoryTest {
             // then
             assertSoftly(softly -> {
                 softly.assertThat(boards.getNumber()).isEqualTo(0);
-                softly.assertThat(boards.getTotalElements()).isEqualTo(3);
-                softly.assertThat(contents.size()).isEqualTo(3);
+                softly.assertThat(boards.getTotalElements()).isEqualTo(totalPostCount / memberCount);
+                softly.assertThat(contents.size()).isEqualTo(defaultPageSize);
                 softly.assertThat(contents)
                         .extracting(Board::getWriterNickname)
                         .allMatch(writerNickname -> writerNickname.equals(searchWriter));


### PR DESCRIPTION
* 기존 조회 수 증가 로직
  * 변경 감지로 Board 도메인에서 viewCount 1 증가하는 로직 구현

### 문제 발생 원인
* 조회수 증가 호출 서비스 메소드에서 `@Transactional(readOnly=true)`로 설정되어 있어서 변경 감지 기능이 비활성화됨.
* 기존에 단순 게시글 조회였으므로, `@Transactional(readOnly=true)`을 설정했었음.

### 해결
* 따라서, 해당 메소드의 `@Transactional(readOnly=true)`을 제거하고, `@Transactional`만 받도록 리팩토링